### PR TITLE
Fix total files query to avoid TypeError

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -243,7 +243,7 @@ class usage_monitor_manager {
         $info->user_count = $DB->count_records('user', ['deleted' => 0]) - 1; // Exclude guest
         $info->active_users = $DB->count_records('user', ['deleted' => 0, 'suspended' => 0]) - 1;
         $info->suspended_users = $DB->count_records('user', ['deleted' => 0, 'suspended' => 1]);
-        $info->total_files = $DB->count_records('files', ['filesize' => ['>', 0]]);
+        $info->total_files = $DB->count_records_select('files', 'filesize > ?', [0]);
         $info->backup_auto_max_kept = get_config('backup', 'backup_auto_max_kept') ?? 0;
         
         // Performance metrics


### PR DESCRIPTION
## Summary
- replace the usage of count_records with count_records_select when counting files bigger than zero to avoid passing an array parameter to the database driver

## Testing
- php -l locallib.php

------
https://chatgpt.com/codex/tasks/task_e_68dae458eb94832a97106f67718a1e50